### PR TITLE
Add Grobid backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,71 @@
 
 A framework to extract bibliographic references from ArXiV submissions, derived
 from the "classic" pipeline deployed in `/proj/ads/abstracts/sources/ArXiV/`.
+The code is in the `ads_ref_extract/` Python package, with diagnostic tooling in
+`diagnostics/`. See `diagnostics/README.md` for a description of those tools.
+
+
+## Launching the pipeline
+
+In ADS' online systems, the new pipeline is launched in a Docker container by
+`docker exec`-ing the `run.py` script in "pipeline" mode. This delegates to
+`ads_ref_extract/compat.py:entrypoint()`. Currently, processing is kicked off by
+the classic backoffice script
+`/proj/ads/abstracts/sources/ArXiv/bin/fulltext.sh`
+
+In "pipeline" mode, the key interfaces with the environment are:
+
+- The list of items to process is read from the `--pipeline PATH` argument.
+- The "session ID" is determined from the directory name of the input path.
+- Item fulltext files are read from `$ADS_ARXIVREFS_FULLTEXT`, or the default
+  value of `$ADS_ABSTRACTS/sources/ArXiv/fulltext`.
+- Output reference files are written inside `$ADS_ARXIVREFS_REFOUT`, which
+  defaults to `$ADS_REFERENCES/sources`.
+- Logs are written inside `$ADS_ARXIVREFS_LOGROOT`, in a subdirectory named
+  with the session ID.
+
+In the "non-pipeline" mode, which is compatible with the historical
+`extractrefs.pl` script:
+
+- The list of items to process is read from stdin.
+- The "session ID" is unspecified.
+- Fulltext inputs and reference outputs are as above.
+- Summary logs are written to stdout, in a format compatible with the historical
+  script.
+- Additional logging information is written to stderr.
+
+To test locally, we recommend using the framework found in the `diagnostics/`
+subdirectory. Some modest configuration is required. You also need to have
+copies of ArXiv data organized according to ADS' system in order for the
+pipeline to be able to do anything useful.
+
+
+## Configuration
+
+Standard ADS environment variables are used as appropriate. Additional
+environment variables are:
+
+- `ADS_ARXIVREFS_FULLTEXT` - the base directory for Arxiv fulltext sources.
+  Defaults to `$ADS_ABSTRACTS/sources/ArXiv/fulltext`.
+- `ADS_ARXIVREFS_GROBID_HOST` - the hostname of the Grobid server, if
+  Grobid-based PDF extraction is being used. Defaults to `localhost`.
+- `ADS_ARXIVREFS_GROBID_PORT` - the port of the Grobid server, if Grobid-based
+  PDF extraction is being used. Defaults to 8070.
+- `ADS_ARXIVREFS_LOGROOT` - the base directory for log file outputs in
+  `--pipeline` mode
+- `ADS_ARXIVREFS_REFOUT` - the base directory for writing the new "target
+  reference" files that represent the pipeline output. Defaults to
+  `$ADS_REFERENCES/sources`.
+
+Additionally, the `run.py` script accepts various command-line arguments
+that can influence its behavior. Use `run.py --help` for a detailed listing.
+Some options of note are:
+
+- `--pdf-backend NAME` - The backend to use for extracting references from
+  PDF files, when TeX-based extraction isn't successful. Valid settings for
+  NAME are `perl` or `grobid`.
+- `--no-tex` - Disable TeX extraction; use PDF-based extraction for all inputs.
+
 
 ## Dockerized classic pipeline
 
@@ -10,18 +75,6 @@ subdirectory. The goal of this variation is stick as closely as possible to the
 classic pipeline, while making a few changes to be deployable in a containerized
 setting.
 
-## New Python implementation
-
-A modernized version of the pipeline is under construction in the
-`ads_ref_extract/` Python package. At the moment, most of the code there has
-to do with parsing pipeline logs to extract analytics about its performance.
-
-## Launching the pipeline
-
-To test locally, we recommend using the framework found in the `diagnostics/`
-subdirectory. Some modest configuration is required. You also need to have
-copies of ArXiv data organized according to ADS' system in order for the
-pipeline to be able to do anything useful.
 
 ## Maintainer(s)
 

--- a/ads_ref_extract/classic_analytics.py
+++ b/ads_ref_extract/classic_analytics.py
@@ -10,7 +10,7 @@ import logging
 import math
 from pathlib import Path
 import subprocess
-from typing import Optional, Set
+from typing import List, Optional, Set
 
 from .config import Config
 from .resolver_cache import ResolverCache
@@ -672,6 +672,9 @@ class ClassicSessionReprocessor(object):
     force = False
     "Whether the extractor should be run in --force mode"
 
+    extra_args: Optional[List[str]] = None
+    "Extra CLI arguments to pass to the processing program"
+
     def __init__(self, config=None, image_name=None, logs_out_base=None):
         if config is not None:
             self.config = config
@@ -761,6 +764,9 @@ class ClassicSessionReprocessor(object):
 
         if self.force:
             argv += ["--force"]
+
+        if self.extra_args:
+            argv += self.extra_args
 
         # Ready to go!
 

--- a/ads_ref_extract/classic_analytics.py
+++ b/ads_ref_extract/classic_analytics.py
@@ -732,7 +732,7 @@ class ClassicSessionReprocessor(object):
             "--name",
             f"arxiv_refextract_repro_{session_id}",
             "-v",
-            f"{self.config.fulltext_base}:/proj/ads/abstracts/sources/ArXiv/fulltext:ro,Z",
+            f"{self.config.fulltext_base}:/fulltext:ro,Z",
             "-v",
             f"{log_dir}:/input_logs/{session_id}:ro,Z",
         ]
@@ -753,6 +753,8 @@ class ClassicSessionReprocessor(object):
             f"ADS_ARXIVREFS_LOGROOT=/{spfx}/logs",
             "-e",
             f"ADS_ARXIVREFS_REFOUT=/{spfx}/results/testing/references/sources",
+            "-e",
+            "ADS_ARXIVREFS_FULLTEXT=/fulltext",
             self.image_name,
             "/app/run.py",
             "--pipeline",

--- a/ads_ref_extract/compat.py
+++ b/ads_ref_extract/compat.py
@@ -70,6 +70,9 @@ class CompatExtractor(object):
     no_pdf = False
     "Do not attempt to process PDF files if original source was LaTeX (implies `no_harvest`)."
 
+    no_tex = False
+    "Do not attempt LaTeX processing."
+
     skip_refs = False
     "If true, don't actually write out the new ('target') reference file."
 
@@ -133,6 +136,11 @@ The fulltext filenames typically are in one of these forms:
             "--no-pdf",
             action="store_true",
             help="Do not attempt to process PDF files if original source was LaTeX (implies --no-harvest)",
+        )
+        parser.add_argument(
+            "--no-tex",
+            action="store_true",
+            help="Do not attempt LaTeX processing",
         )
         parser.add_argument(
             "--skip-refs",
@@ -253,6 +261,7 @@ The fulltext filenames typically are in one of these forms:
         inst.force = settings.force
         inst.no_harvest = settings.no_harvest or settings.no_pdf
         inst.no_pdf = settings.no_pdf
+        inst.no_tex = settings.no_tex
         inst.skip_refs = settings.skip_refs
         inst.debug_tex = settings.debug_tex
         inst.debug_source_files_dir = settings.debug_sourcefiles
@@ -531,7 +540,7 @@ The fulltext filenames typically are in one of these forms:
 
         wrote_refs = False
 
-        if not is_pdf:
+        if not is_pdf and not self.no_tex:
             if self.debug_source_files_dir is None:
                 workdir = None
             else:

--- a/ads_ref_extract/compat.py
+++ b/ads_ref_extract/compat.py
@@ -606,8 +606,9 @@ The fulltext filenames typically are in one of these forms:
                 self.item_give_up("missing-pdf")
                 return None
 
+            tr_path.parent.mkdir(parents=True, exist_ok=True)
+
             if self.pdf_backend == "perl":
-                tr_path.parent.mkdir(parents=True, exist_ok=True)
                 argv = [str(self.pdf_helper), str(pdf_path), str(tr_path), bibcode]
 
                 try:
@@ -620,6 +621,10 @@ The fulltext filenames typically are in one of these forms:
                         argv=argv,
                         e=e,
                     )
+            elif self.pdf_backend == "grobid":
+                from .grobid import extract_references
+
+                extract_references(self, pdf_path, tr_path, bibcode)
             else:
                 # This should be handled much sooner!
                 self.item_warn("unhandled PDF backend name", backend=self.pdf_backend)

--- a/ads_ref_extract/config.py
+++ b/ads_ref_extract/config.py
@@ -44,6 +44,18 @@ class Config(object):
     new processing. Defaults to ``$ADS_ABSTRACTS/sources/ArXiv/log``.
     """
 
+    grobid_host: str = "localhost"
+    """
+    The host to contact for Grobid-based PDF reference extraction, if that
+    mode is being used. Defaults to ``"localhost"``.
+    """
+
+    grobid_port: int = 8070
+    """
+    The port to use for communicating with the Grobid server, if that mode is
+    being used. Defaults to 8070.
+    """
+
     @classmethod
     def new_defaults(cls):
         """
@@ -73,6 +85,10 @@ class Config(object):
 
         # This assumes that we're running in the standard Docker container:
         inst.tex_bin_dir = Path("/src/tex/bin/x86_64-linux")
+
+        inst.grobid_host = os.environ.get("ADS_ARXIVREFS_GROBID_HOST", "localhost")
+        inst.grobid_port = int(os.environ.get("ADS_ARXIVREFS_GROBID_PORT", "8070"))
+
         return inst
 
     def classic_session_log_path(self, session_id):

--- a/ads_ref_extract/grobid.py
+++ b/ads_ref_extract/grobid.py
@@ -1,0 +1,141 @@
+"""
+PDF reference extraction using GROBID.
+
+Note that this module depends on the ``grobid_client_python`` package
+(https://github.com/kermitt2/grobid_client_python), which is not on PyPI. There
+are several other Grobid client packages around, some with the same module name,
+but they don't seem able to meet our needs.
+"""
+
+__all__ = ["extract_references"]
+
+import argparse
+from grobid_client.grobid_client import GrobidClient
+from logging import Logger
+from pathlib import Path
+from typing import Generator, Tuple
+from xml.etree import ElementTree as etree
+
+from .compat import CompatExtractor
+from .config import Config
+
+
+__all__ = ["extract_references"]
+
+
+def extract_references(
+    session: CompatExtractor,
+    pdf_path: Path,
+    tr_path: Path,
+    bibcode: str,
+) -> int:
+    """
+    Extract references from a PDF file using GROBID.
+
+    Parameters
+    ----------
+    session : CompatExtractor
+        The extraction session object
+    pdf_path : Path
+        The absolute path of the PDF file
+    tr_path : Path
+        The absolute path of the target output references file
+    bibcode : str
+        The bibcode associated with the ArXiv submission
+
+    Returns
+    -------
+    If a nonnegative integer, the number of references extracted. This indicates
+    successful extraction. If the return value is a negative integer, extraction
+    failed.
+    """
+    http_status, result = _call_grobid(pdf_path)
+
+    if http_status != 200:
+        session.item_give_up("GROBID returned an error code", code=http_status)
+        return -1
+
+    if not result:
+        session.item_give_up("GROBID returned an empty result", code=http_status)
+        return -1
+
+    n = 0
+
+    with tr_path.open("wt") as f:
+        print(f"%R {bibcode}", file=f)
+        print("%Z", file=f)
+
+        for ref in _get_refstrings(result):
+            print(ref, file=f)
+            n += 1
+
+    return n
+
+
+def _call_grobid(pdf_path: Path) -> Tuple[int, str]:
+    client = GrobidClient(check_server=False)
+    _pdf_path, http_status, result = client.process_pdf(
+        "processReferences",
+        str(pdf_path),
+        False,  # generateIDs
+        False,  # consolidateHeader
+        False,  # consolidateCitations
+        True,  # includeRawCitations
+        False,  # includeRawAffiliations
+        None,  # teiCoordinates
+        False,  # segmentSentences
+    )
+    return http_status, result
+
+
+def _get_refstrings(result: str) -> Generator[str, None, None]:
+    elem = etree.fromstring(result)
+
+    for note in elem.iter("{http://www.tei-c.org/ns/1.0}note"):
+        if note.attrib.get("type") == "raw_reference":
+            yield note.text
+
+
+# Diagnostic CLI
+
+
+def _do_oneoff(settings):
+    from .utils import get_quick_logger
+
+    config = Config.new_defaults()
+    logger = get_quick_logger("grobid-cli")
+
+    pdf_path = config.fulltext_base / f"{settings.item}.pdf"
+    if not pdf_path.exists():
+        raise Exception(f"no such file `{pdf_path}`")
+
+    http_status, result = _call_grobid(pdf_path)
+
+    if http_status != 200:
+        raise Exception(f"GROBID returned status {http_status}, not 200 as expected")
+
+    for ref in _get_refstrings(result):
+        print(ref)
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="subcommand")
+
+    p = commands.add_parser("oneoff")
+    p.add_argument("item", metavar="ITEM", help="An ArXiv item ID")
+
+    settings = parser.parse_args()
+    if settings.subcommand is None:
+        raise Exception("use a subcommand: oneoff")
+
+    if settings.subcommand == "oneoff":
+        _do_oneoff(settings)
+    else:
+        raise Exception(
+            f"unknown subcommand `{settings.subcommand}`; run without arguments for a list"
+        )
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/ads_ref_extract/grobid.py
+++ b/ads_ref_extract/grobid.py
@@ -93,7 +93,12 @@ def _get_refstrings(result: str) -> Generator[str, None, None]:
 
     for note in elem.iter("{http://www.tei-c.org/ns/1.0}note"):
         if note.attrib.get("type") == "raw_reference":
-            yield note.text
+            text = note.text
+
+            # Hyphenation normalization helps:
+            text = text.replace("- ", "")
+
+            yield text
 
 
 # Diagnostic CLI

--- a/ads_ref_extract/normalize.py
+++ b/ads_ref_extract/normalize.py
@@ -10,7 +10,7 @@
 from abc import ABC, abstractmethod
 import unicodedata
 
-__all__ = ["refstring_normalizer"]
+__all__ = ["refstring_normalizer", "to_ascii"]
 
 #: Control characters.
 CONTROLS = {
@@ -196,7 +196,7 @@ class Normalizer(BaseNormalizer):
 
         # Normalize unusual whitespace not caught by unicodedata
         # text = text.replace('\u000b', ' ').replace('\u000c', ' ').replace(u'\u0085', ' ')
-        text = text.replace("\u000b", " ").replace(u"\u0085", " ")
+        text = text.replace("\u000b", " ").replace("\u0085", " ")
         text = (
             text.replace("\u2028", "\n")
             .replace("\u2029", "\n")
@@ -257,3 +257,7 @@ refstring_normalizer = Normalizer(
     slashes=True,
     tildes=True,
 )
+
+
+def to_ascii(text: str) -> str:
+    return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")

--- a/ads_ref_extract/tex.py
+++ b/ads_ref_extract/tex.py
@@ -836,29 +836,13 @@ class TexSources(object):
 # CLI helper support
 
 
-def _get_quick_logger():
-    import logging
-
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s %(levelname)s\t%(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-
-    logger = logging.getLogger("tex-cli")
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
-    return logger
-
-
 def _do_one(settings, until):
     from .config import Config
+    from .utils import get_quick_logger
 
     session = CompatExtractor()
     session.config = Config.new_defaults()
-    session.logger = _get_quick_logger()
+    session.logger = get_quick_logger("tex-cli")
     session.log_stream = sys.stderr
     session.output_stream = sys.stdout
 

--- a/ads_ref_extract/utils.py
+++ b/ads_ref_extract/utils.py
@@ -2,7 +2,31 @@
 Miscellaneous utilities that don't fit anywhere else.
 """
 
-__all__ = ["split_item_path"]
+__all__ = ["get_quick_logger", "split_item_path"]
+
+import logging
+import sys
+
+
+def get_quick_logger(name: str, level: int = logging.DEBUG) -> logging.Logger:
+    """
+    Get a basic logger for CLI utilities.
+
+    This prints to stderr, since the standard usage of this program needs to
+    keep its stdout pristine.
+    """
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s\t%(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    logger = logging.getLogger(name)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger
 
 
 def split_item_path(item_path):

--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -72,6 +72,10 @@ tag named "prod" must exist; its associated logs will be used as the
 source-of-truth about which items should be processed (as well as their
 bibcodes).
 
+If set, the environment variable `$REPRO_ARGS` can be used to pass extra
+command-line arguments to the processing tool, which is run inside a Docker
+container.
+
 On @pkgw's laptop, reprocessing averages about 2 seconds per item, which means
 that reprocessing usually takes about 45 minutes for a typical session.
 

--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -157,3 +157,22 @@ understanding if/how a particular refstring is resolving successfully or not.
 
 If any API calls need to be made, the environment variable `$ADS_DEV_KEY` must
 be set as above.
+
+### ./make-training-set.py [-m MAX-RESOLVES] {TAG}
+
+Identify Arxiv submissions to go into a training set for ADS' reference
+extraction tools.
+
+In particular, this script prints out the identifiers of items in the specified
+tag where every single refstring successfully resolves into a bibcode. The
+assumption is that if this is the case, the (presumably TeX-based) extraction
+went well and the associated information should make for a good test case for
+PDF-based extraction. This filter will obviously yield a very biased subset of
+the inputs, but that's not necessarily a problem. The search is done over every
+item in every session, so that tag's results should probably include only a
+relatively small number of items. In the initial processing, about 2% of Arxiv
+items meet the criterion.
+
+This will likely need to invoke the reference resolver because the default
+analysis only looks at *changed* refstrings between two samples, while this
+analysis needs to resolve everything.

--- a/diagnostics/cmp-resolved.py
+++ b/diagnostics/cmp-resolved.py
@@ -78,7 +78,7 @@ with resolver_cache.ResolverCache(db_path) as rcache:
     subsample_delta = 0
 
     print(
-        "{:20}  {:12}  {:>4}  {:>8}  {:>6}  {:>6}  {:>6}".format(
+        "{:40}  {:12}  {:>4}  {:>8}  {:>6}  {:>6}  {:>6}".format(
             "ITEM", "EXT-A/B", "NR_A", "NR_(B-A)", "NLOST", "NGAIN", "DSCORE"
         )
     )
@@ -88,7 +88,7 @@ with resolver_cache.ResolverCache(db_path) as rcache:
     ):
         ext = f"{info.A_ext}/{info.B_ext}"
         print(
-            f"{stem:20}  {ext:12}  {info.n_strings_A:4d}  {info.n_strings_B - info.n_strings_A:+8d}  {info.n_lost:6d}  {info.n_gained:6d}  {info.score_delta:+6.1f}"
+            f"{stem:40}  {ext:12}  {info.n_strings_A:4d}  {info.n_strings_B - info.n_strings_A:+8d}  {info.n_lost:6d}  {info.n_gained:6d}  {info.score_delta:+6.1f}"
         )
         n_tried_A += info.n_tried_A
         n_tried_B += info.n_tried_B
@@ -122,10 +122,10 @@ with resolver_cache.ResolverCache(db_path) as rcache:
     print()
     print(f"Total score delta: {subsample_delta:+.1f}")
     print(
-        f"Total A subsample score: {subsample_A_score:+.1f} (fractional improvement: {subsample_delta / subsample_A_score:+.3f})"
+        f"Total A subsample score: {subsample_A_score:+.1f} (fractional improvement in B: {subsample_delta / subsample_A_score:+.3f})"
     )
     print(
-        f"Estimated A sample score: {sample_A_score_est:+.1f} (fractional improvement: {subsample_delta / sample_A_score_est:+.3f})"
+        f"Estimated A sample score: {sample_A_score_est:+.1f} (fractional improvement in B: {subsample_delta / sample_A_score_est:+.3f})"
     )
     print(f"Estimated A bibcodes: {n_strings_A * rA:.0f}")
     print(f"Estimated B bibcodes: {n_strings_B * rB:.0f}")

--- a/diagnostics/make-training-set.py
+++ b/diagnostics/make-training-set.py
@@ -1,0 +1,107 @@
+#! /usr/bin/env python3
+
+"""
+Identify Arxiv preprints to go into a training set for PDF reference extraction.
+
+We look for items where every single refstring resolves into a bibcode. Note
+that this might require extra refstring resolutions compared to
+`cmp-resolved.py`, since that script only resolves refstrings that *change*
+between two processing sessions.
+"""
+
+import argparse
+import logging
+import os.path as osp
+from pathlib import Path
+import sys
+
+# Make sure we can find the Python package:
+diagnostics_dir = osp.dirname(__file__)
+app_dir = osp.join(diagnostics_dir, osp.pardir)
+sys.path.append(app_dir)
+
+from ads_ref_extract import config, classic_analytics, resolver_cache, utils
+
+logger = utils.get_quick_logger("make-arxiv-training-set")
+
+# Args
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-m",
+    "--max-resolves",
+    type=int,
+    help="Maximum number of refstring resolutions to perform",
+)
+parser.add_argument("tag")
+settings = parser.parse_args()
+
+diagnostics_cfg = config.parse_dumb_config_file(
+    osp.join(diagnostics_dir, "diagnostics.cfg")
+)
+
+cfg = config.Config.new_defaults()
+cfg.logs_base = Path(f"{diagnostics_cfg['results_dir']}/{settings.tag}/logs")
+cfg.target_refs_base = Path(
+    f"{diagnostics_cfg['results_dir']}/{settings.tag}/references/sources"
+)
+
+db_path = diagnostics_cfg["resolver_cache_db_path"]
+
+# Get all of the stems
+
+stems = {}
+
+for session_id in cfg.logs_base.iterdir():
+    er = cfg.classic_session_log_path(session_id) / "extractrefs.out"
+
+    for stem, ext, tr_path in classic_analytics._target_refs_for_session(
+        er, True, cfg, classic_analytics.default_logger
+    ):
+        if tr_path is not None:
+            stems[stem] = tr_path
+
+# Find out which ones are "perfect".
+
+n_refs_resolved = 0
+n_checked = 0
+n_accepted = 0
+
+with resolver_cache.ResolverCache(db_path) as rcache:
+    for stem, tr_path in stems.items():
+        refstrings = classic_analytics._maybe_load_raw_file(
+            tr_path, classic_analytics.default_logger
+        )
+
+        # Once we hit the maximum number of resolves, still check
+        # any items for which no resolutions are needed.
+        nr = rcache.count_need_rpc(refstrings)
+        if nr != 0 and n_refs_resolved + nr > settings.max_resolves:
+            continue
+
+        n_checked += 1
+
+        if not refstrings:
+            continue
+
+        any_bad = False
+
+        for rs, ri in rcache.resolve(
+            refstrings, logger=logger, level=logging.DEBUG - 1
+        ).items():
+            if ri.score <= classic_analytics.SUCCESSFUL_RESOLUTION_THRESHOLD:
+                any_bad = True
+                break
+
+        n_refs_resolved += nr
+
+        if any_bad:
+            continue
+
+        print(stem)
+        n_accepted += 1
+
+print()
+print(f">>> {len(stems)} items considered")
+print(f">>> {n_checked} had all resolutions available")
+print(f">>> {n_accepted} accepted ({100 * n_accepted / n_checked:.1f}%)")

--- a/diagnostics/repro.py
+++ b/diagnostics/repro.py
@@ -8,8 +8,12 @@ Reprocess a daily Arxiv update. Usage:
 ... where <tag> is the name of the directory within `results_dir` where outputs
 (logs and "target references" files) will be stored, and <sessionid> is the
 Arxiv update session name (e.g. 2021-11-07).
+
+Set the environment variable $REPRO_ARGS to send additional options to the
+pipeline processing program.
 """
 
+import os
 import os.path as osp
 from pathlib import Path
 import sys
@@ -42,6 +46,10 @@ repro.image_name = diagnostics_cfg["extractor_image"]
 repro.custom_app_dir = app_dir
 repro.debug = True
 repro.force = True
+
+extra_args_text = os.environ.get("REPRO_ARGS")
+if extra_args_text:
+    repro.extra_args = extra_args_text.split()
 
 # These are the logs that we scan in order to figure out what to process:
 cfg.logs_base = Path(f"{diagnostics_cfg['results_dir']}/prod/logs")

--- a/diagnostics/repro.py
+++ b/diagnostics/repro.py
@@ -3,16 +3,20 @@
 """
 Reprocess a daily Arxiv update. Usage:
 
-    ./repro.py <tag> <sessionid>
+    ./repro.py [--ref <reftag>] <tag> <sessionid>
 
 ... where <tag> is the name of the directory within `results_dir` where outputs
 (logs and "target references" files) will be stored, and <sessionid> is the
 Arxiv update session name (e.g. 2021-11-07).
 
+<reftag> is the "reference" tag, which is the template source used to identify
+which items to process. It defaults to `prod`.
+
 Set the environment variable $REPRO_ARGS to send additional options to the
 pipeline processing program.
 """
 
+import argparse
 import os
 import os.path as osp
 from pathlib import Path
@@ -25,12 +29,16 @@ sys.path.append(app_dir)
 
 from ads_ref_extract import config, classic_analytics
 
-if len(sys.argv) != 3:
-    print(f"usage: {sys.argv[0]} <tag> <session-id>")
-    sys.exit(1)
-
-tag = sys.argv[1]
-session_id = sys.argv[2]
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--ref",
+    dest="ref_tag",
+    default="prod",
+    help="Tag to use as a reference",
+)
+parser.add_argument("tag")
+parser.add_argument("session_id")
+settings = parser.parse_args()
 
 diagnostics_cfg = config.parse_dumb_config_file(
     osp.join(diagnostics_dir, "diagnostics.cfg")
@@ -40,7 +48,7 @@ repro = classic_analytics.ClassicSessionReprocessor(config=cfg)
 
 cfg.fulltext_base = Path(diagnostics_cfg["fulltext_dir"])
 cfg.target_refs_base = Path(
-    f"{diagnostics_cfg['results_dir']}/{tag}/references/sources"
+    f"{diagnostics_cfg['results_dir']}/{settings.tag}/references/sources"
 )
 repro.image_name = diagnostics_cfg["extractor_image"]
 repro.custom_app_dir = app_dir
@@ -52,15 +60,15 @@ if extra_args_text:
     repro.extra_args = extra_args_text.split()
 
 # These are the logs that we scan in order to figure out what to process:
-cfg.logs_base = Path(f"{diagnostics_cfg['results_dir']}/prod/logs")
+cfg.logs_base = Path(f"{diagnostics_cfg['results_dir']}/{settings.ref_tag}/logs")
 # These are the logs we'll create:
-repro.logs_out_base = Path(f"{diagnostics_cfg['results_dir']}/{tag}/logs")
+repro.logs_out_base = Path(f"{diagnostics_cfg['results_dir']}/{settings.tag}/logs")
 
 # OK, let's do it.
-repro.reprocess(session_id)
+repro.reprocess(settings.session_id)
 
 cfg.logs_base = repro.logs_out_base
 info = classic_analytics.analyze_session(
-    session_id, cfg, reconstruct_targets=True, check_resolved=False
+    settings.session_id, cfg, reconstruct_targets=True, check_resolved=False
 )
 print(info)


### PR DESCRIPTION
This adds support for Grobid-based PDF extraction, and various other minor cleanups and improvements. In particular, we also add a script for identifying Arxiv items that should make for good test cases for PDF-based reference extraction — it looks for ones where *all* of the extracted refstrings successfully resolve to bibcodes, indicating that our TeX-based analysis has performed well.